### PR TITLE
add proguard rule to keep geosubmit classes - fix #81

### DIFF
--- a/app/gson.pro
+++ b/app/gson.pro
@@ -12,6 +12,7 @@
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { <fields>; }
+-keep class xyz.malkki.neostumbler.geosubmit.** { <fields>; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)


### PR DESCRIPTION
This definitely fixes the problem, but _may_ be too liberal and keep more metadata than absolutely needed for (de-)serializing reports.

I didn't have the patience to read deeper into ProGuard and try many different rules :sweat_smile: