### PR TITLE
Update German translation

### DIFF
--- a/app/src/full/res/values-de-rDE/strings.xml
+++ b/app/src/full/res/values-de-rDE/strings.xml
@@ -2,6 +2,8 @@
     <string name="prefer_fused_location">Fused Location Provider bevorzugen</string>
     <string name="autoscan_when_moving">Automatisch scannen wenn in Bewegung</string>
 
+    <string name="autoscan_failed_to_enable">Konnte automatisches Scannen nicht einschalten</string>
+    
     <string name="permission_rationale_background_location_autoscan">
         Scan automatisch starten benötigt die Berechtigung für Hintergrund Standort
     </string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -41,7 +41,7 @@
     <string name="stop_scanning">Scan stoppen</string>
 
     <string name="delete_report">Bericht löschen</string>
-    <string name="delete_report_confirmation">Bust Du Dir sicher, dass Du den Bericht löschen möchtest?</string>
+    <string name="delete_report_confirmation">Sind Sie sicher, dass Sie den Bericht löschen möchten?</string>
     
     <string name="toast_reports_uploaded">%d Berichte hochgeladen</string>
     <string name="toast_reports_upload_failed">Berichte hochladen fehlgeschlagen</string>
@@ -84,10 +84,10 @@
     <string name="path">Pfad</string>
     <string name="api_key">API Schlüssel (optional)</string>
     
-    <string name="settings_ignore_wifi_scan_throttling">Ignoriere WLAN Suchdrosselung</string>
-    <string name="wifi_scan_throttling">WLAN Suchdrosselung</string>
+    <string name="settings_ignore_wifi_scan_throttling">Ignoriere WLAN-Suchdrosselung</string>
+    <string name="wifi_scan_throttling">WLAN-Suchdrosselung</string>
     <string name="wifi_scan_throttling_explanation">
-        Du musst die WLAN-Suchdrosselung in Deinen Geräteeinstellungen deaktivieren um diese Funktion zu ermöglichen. Normalerweise kann dies in den Entwicklereinstellungen getan werden
+        Sie müssen die Drosselung der WLAN-Suche in Ihren Geräteeinstellungen deaktivieren um diese Funktion zu ermöglichen. Normalerweise kann dies in den Entwicklereinstellungen getan werden
     </string>
     
     <string name="show_my_location">Zeige meinen Standort</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -6,6 +6,9 @@
 
     <string name="no_thanks">Nein danke</string>
 
+    <string name="yes">Ja</string>
+    <string name="no">Nein</string>
+    
     <string name="reset">Zurücksetzen</string>
     <string name="save">Speichern</string>
 
@@ -37,6 +40,9 @@
     <string name="start_scanning">Scan starten</string>
     <string name="stop_scanning">Scan stoppen</string>
 
+    <string name="delete_report">Bericht löschen</string>
+    <string name="delete_report_confirmation">Bust Du Dir sicher, dass Du den Bericht löschen möchtest?</string>
+    
     <string name="toast_reports_uploaded">%d Berichte hochgeladen</string>
     <string name="toast_reports_upload_failed">Berichte hochladen fehlgeschlagen</string>
 
@@ -77,21 +83,31 @@
     <string name="endpoint">Endpunkt</string>
     <string name="path">Pfad</string>
     <string name="api_key">API Schlüssel (optional)</string>
-
+    
+    <string name="settings_ignore_wifi_scan_throttling">Ignoriere WLAN Suchdrosselung</string>
+    <string name="wifi_scan_throttling">WLAN Suchdrosselung</string>
+    <string name="wifi_scan_throttling_explanation">
+        Du musst die WLAN-Suchdrosselung in Deinen Geräteeinstellungen deaktivieren um diese Funktion zu ermöglichen. Normalerweise kann dies in den Entwicklereinstellungen getan werden
+    </string>
+    
     <string name="show_my_location">Zeige meinen Standort</string>
 
     <string name="permission_rationale_fine_location">
         Zugriff auf den aktuellen Standort benötigt die Berechtigung für den Genauen Standort
     </string>
+    
     <string name="permission_rationale_read_phone_state">
         Zugriff auf Telefon wird benötigt um Funkzellen mit allen SIM Karten zu scannen
     </string>
+    
     <string name="permission_rationale_bluetooth">
         Bluetooth Beacon scannen benötigt die Bluetooth Berechtigung
     </string>
+    
     <string name="permission_rationale_post_notifications">
         Status Benachrichtigung anzeigen benötigt die Berechtigung Benachrichtigung
     </string>
+    
     <string name="permission_rationale_background_location_quick_settings">
         Scannen starten von der Schnelleinstellungskachel benötigt im Hintergrund Zugriff auf den Standort
     </string>


### PR DESCRIPTION
I saw your heads up for the German translation and quickly added it, I hope I did everything correctly and added all missing strings.
I also opted for a more formal speech, as that's also what TowerCollecter uses and it seems that it was also used in the Portuguese translation.
As for the Wi-Fi scan throttling, I mostly went with what felt and sounded right while not straying too far from the Android translation as a 1:1 usage of that would sound a bit alien, but I stuck to what Android uses in the third string to make sure it can be easily found when searching for the setting in the developer settings.