### PR TITLE
Use BeaconDB as default instead of MLS

### DIFF
--- a/app/src/main/java/xyz/malkki/neostumbler/geosubmit/GeosubmitParams.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/geosubmit/GeosubmitParams.kt
@@ -10,8 +10,7 @@ data class GeosubmitParams(
     val apiKey: String?
 ) {
     companion object {
-        //NOTE: MLS does not accept data submissions anymore, this is used as a default just to show an example
-        const val DEFAULT_BASE_URL = "https://location.services.mozilla.com"
+        const val DEFAULT_BASE_URL = "https://api.beacondb.net"
 
         const val DEFAULT_PATH = "/v2/geosubmit"
     }


### PR DESCRIPTION
<img width="300px" src="https://github.com/user-attachments/assets/ada219d8-186f-46f0-99a3-215780bd9a69"/>

Should I also remove the MLS depreciation warning, or just modify it?:
<img width="200px" src="https://github.com/user-attachments/assets/742b1382-3c29-4d75-b028-f7cdafd6e6db"/>

fixes https://github.com/mjaakko/NeoStumbler/issues/189