### PR TITLE
update: Change base URL and mention beaconDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 
 # NeoStumbler
 
-NeoStumbler is an Android application for collecting locations of cell towers, Wi-Fi access points and Bluetooth beacons to geolocation services, which have an API compatible with [Ichnaea](https://ichnaea.readthedocs.io/en/latest/api/geosubmit2.html) (i.e. Mozilla Location Services).
+NeoStumbler is an Android application for collecting locations of cell towers, Wi-Fi access points and Bluetooth beacons to geolocation services, which have an API compatible with [Ichnaea](https://ichnaea.readthedocs.io/en/latest/api/geosubmit2.html) (i.e. Mozilla Location Services and now BeaconDB).
+
+> [!NOTE]
+> Mozilla Location Service (MLS) will retire it's service entirely very soon.
+> Multiple entities have access to their dataset, most notably, [BeaconDB](https://beacondb.net) will be their successor and accept data submissions.
 
 ## Downloads
 

--- a/app/src/main/java/xyz/malkki/neostumbler/geosubmit/GeosubmitParams.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/geosubmit/GeosubmitParams.kt
@@ -10,8 +10,8 @@ data class GeosubmitParams(
     val apiKey: String?
 ) {
     companion object {
-        //NOTE: MLS does not accept data submissions anymore, this is used as a default just to show an example
-        const val DEFAULT_BASE_URL = "https://location.services.mozilla.com"
+        //NOTE: MLS does not accept data submissions anymore, beacondb will continue their service
+        const val DEFAULT_BASE_URL = "https://beacondb.net"
 
         const val DEFAULT_PATH = "/v2/geosubmit"
     }


### PR DESCRIPTION
It seems BeaconDB will be the successor to MLS. They have a guide on their website, which would then not be needed anymore if the base URL is changed.

They use the same /v2/geosubmit service

The popup message about MLS could be changed too.

---

I see you already have beaconDB in the "suggested providers". But the URL is different.