### PR TITLE
fix: correct the baseUrl for BeaconDB

### DIFF
--- a/app/src/main/res/raw/suggested_services.json
+++ b/app/src/main/res/raw/suggested_services.json
@@ -5,7 +5,7 @@
     "termsOfUse": "https://beacondb.net/privacy/",
     "hostedBy": "Joel Koen",
     "endpoint": {
-      "baseUrl": "https://api.beacondb.net",
+      "baseUrl": "https://beacondb.net",
       "path": "/v2/geosubmit"
     }
   }


### PR DESCRIPTION
Correct the baseUrl for BeaconDB to match the instructions at https://beacondb.net/