### PR TITLE
Default to BeaconDB instead of MLS

### DIFF
--- a/app/src/main/java/xyz/malkki/neostumbler/geosubmit/GeosubmitParams.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/geosubmit/GeosubmitParams.kt
@@ -1,7 +1,13 @@
 package xyz.malkki.neostumbler.geosubmit
 
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import xyz.malkki.neostumbler.StumblerApplication
+import xyz.malkki.neostumbler.constants.PreferenceKeys
 
 
 data class GeosubmitParams(
@@ -10,8 +16,8 @@ data class GeosubmitParams(
     val apiKey: String?
 ) {
     companion object {
-        //NOTE: MLS does not accept data submissions anymore, this is used as a default just to show an example
-        const val DEFAULT_BASE_URL = "https://location.services.mozilla.com"
+        const val DEFAULT_BASE_URL = "https://api.beacondb.net"
+        const val MLS_BASE_URL = "https://location.services.mozilla.com"
 
         const val DEFAULT_PATH = "/v2/geosubmit"
     }
@@ -43,4 +49,17 @@ data class GeosubmitParams(
             }
         }.joinToString("")
     }
+}
+
+fun StumblerApplication.geosubmitParamsFlow(): Flow<GeosubmitParams> {
+    return this.settingsStore.data
+        .map { prefs ->
+            val endpoint = prefs[stringPreferencesKey(PreferenceKeys.GEOSUBMIT_ENDPOINT)]
+                ?: GeosubmitParams.DEFAULT_BASE_URL
+            val path = prefs[stringPreferencesKey(PreferenceKeys.GEOSUBMIT_PATH)]
+                ?: GeosubmitParams.DEFAULT_PATH
+            val apiKey = prefs[stringPreferencesKey(PreferenceKeys.GEOSUBMIT_API_KEY)]
+
+            GeosubmitParams(endpoint, path, apiKey)
+        }
 }

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/composables/MLSWarningDialog.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/composables/MLSWarningDialog.kt
@@ -9,15 +9,26 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import xyz.malkki.neostumbler.R
 import xyz.malkki.neostumbler.StumblerApplication
+import xyz.malkki.neostumbler.geosubmit.GeosubmitParams.Companion.MLS_BASE_URL
+import xyz.malkki.neostumbler.geosubmit.geosubmitParamsFlow
 import xyz.malkki.neostumbler.utils.OneTimeActionHelper
 
 private const val MLS_WARNING = "mls_warning"
 
 @Composable
 fun MLSWarningDialog() {
+    val application = (LocalContext.current.applicationContext as StumblerApplication)
+    val isUploadingToMls = application.geosubmitParamsFlow().map { params ->
+        params.baseUrl.startsWith(MLS_BASE_URL)
+    }.collectAsState(false)
+    if (!isUploadingToMls.value) {
+        return
+    }
+
     val context = LocalContext.current
 
     val coroutineScope = rememberCoroutineScope()


### PR DESCRIPTION
MLS is no longer operational. Let's make it as easy as possible for users to contribute data. It should work out of the box, users should not have to manually change settings to get basic functionality to work.