### PR TITLE
Restore zoom + camera position state when returning to map

### DIFF
--- a/app/src/main/java/xyz/malkki/neostumbler/common/LatLng.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/common/LatLng.kt
@@ -6,4 +6,14 @@ package xyz.malkki.neostumbler.common
 data class LatLng(
     val latitude: Double,
     val longitude: Double
-)
+) {
+    companion object {
+        val ORIGIN = LatLng(0.0, 0.0)
+    }
+
+    fun isOrigin(): Boolean = this == ORIGIN
+
+    fun asMapLibreLatLng(): org.maplibre.android.geometry.LatLng {
+        return org.maplibre.android.geometry.LatLng(latitude, longitude)
+    }
+}

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/screens/MapScreen.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/screens/MapScreen.kt
@@ -201,19 +201,16 @@ fun MapScreen(mapViewModel: MapViewModel = viewModel()) {
                     mapView.lifecycle = lifecycle
 
                     mapView.getMapAsync { map ->
-                        if (map.cameraPosition.target == null || (map.cameraPosition.target?.latitude == 0.0 && map.cameraPosition.target?.longitude == 0.0)) {
-                            if (latestReportPosition.value != null) {
-                                map.cameraPosition = CameraPosition.Builder()
-                                    .target(latestReportPosition.value?.let { LatLng(it.latitude, it.longitude) })
-                                    .zoom(10.0)
-                                    .build()
-                            } else {
-                                map.cameraPosition = CameraPosition.Builder()
-                                    .target(LatLng(mapViewModel.mapCenter.value.latitude, mapViewModel.mapCenter.value.longitude))
-                                    .zoom(mapViewModel.zoom.value)
-                                    .build()
-                            }
+                        // Call repeatedly in update() because latestReportPosition may not be available in factory()
+                        val target = if (mapViewModel.mapCenter.value.isOrigin()) {
+                            latestReportPosition.value
+                        } else {
+                            mapViewModel.mapCenter.value
                         }
+                        map.cameraPosition = CameraPosition.Builder()
+                            .target(target?.asMapLibreLatLng())
+                            .zoom(mapViewModel.zoom.value)
+                            .build()
 
                         if (myLocation.value != null && map.locationComponent.isLocationComponentActivated) {
                             map.locationComponent.forceLocationUpdate(myLocation.value!!.location)

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/viewmodel/MapViewModel.kt
@@ -74,11 +74,11 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
 
     private val showMyLocation = MutableStateFlow(getApplication<StumblerApplication>().checkMissingPermissions(Manifest.permission.ACCESS_COARSE_LOCATION).isEmpty())
 
-    private val _mapCenter = MutableStateFlow<LatLng>(LatLng(0.0, 0.0))
+    private val _mapCenter = MutableStateFlow<LatLng>(LatLng.ORIGIN)
     val mapCenter: StateFlow<LatLng>
         get() = _mapCenter.asStateFlow()
 
-    private val _zoom = MutableStateFlow(5.0)
+    private val _zoom = MutableStateFlow(12.0)
     val zoom: StateFlow<Double>
         get() = _zoom.asStateFlow()
 


### PR DESCRIPTION
Previously, when switching between tabs and returning to the map, the state would be reset to the latestReportPosition.
(Personally, especially the zoom being reset annoys me, since when mapping in a city I zoom in much more than the default of 10. Even the 12 that I now changed the default to is still quite far out for city/street-level.)

Instead, restore it to the last position and zoom that the user navigated to.

Also move this logic from update() to factory(), since it only needs to run once.