### PR TITLE
translation: fastlane: remove all duplicate translated app titles

### DIFF
--- a/fastlane/metadata/android/cs-CZ/title.txt
+++ b/fastlane/metadata/android/cs-CZ/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/de-DE/title.txt
+++ b/fastlane/metadata/android/de-DE/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/fr-FR/title.txt
+++ b/fastlane/metadata/android/fr-FR/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/hu-HU/title.txt
+++ b/fastlane/metadata/android/hu-HU/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/lt/title.txt
+++ b/fastlane/metadata/android/lt/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/nl-NL/title.txt
+++ b/fastlane/metadata/android/nl-NL/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/pt-BR/title.txt
+++ b/fastlane/metadata/android/pt-BR/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/pt/title.txt
+++ b/fastlane/metadata/android/pt/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/ru-RU/title.txt
+++ b/fastlane/metadata/android/ru-RU/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/uk/title.txt
+++ b/fastlane/metadata/android/uk/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler

--- a/fastlane/metadata/android/zh-CN/title.txt
+++ b/fastlane/metadata/android/zh-CN/title.txt
@@ -1,1 +1,0 @@
-NeoStumbler


### PR DESCRIPTION
no reason to remove them but also no reason to keep them around, just... cleaning!