### PR TITLE
Sort reports by ID to avoid duplicate reports on different pages

### DIFF
--- a/app/data/reports/room/src/main/kotlin/xyz/malkki/neostumbler/db/dao/ReportDao.kt
+++ b/app/data/reports/room/src/main/kotlin/xyz/malkki/neostumbler/db/dao/ReportDao.kt
@@ -59,7 +59,7 @@ internal interface ReportDao {
         FROM Report r
         INNER JOIN PositionEntity p ON r.id = p.reportId
         WHERE r.uploaded = 0
-        ORDER BY r.timestamp DESC
+        ORDER BY r.id DESC
     """
     )
     fun getAllReportsWithStats(): PagingSource<Int, ReportWithStats>


### PR DESCRIPTION
Fixes #980 