### PR TITLE
feat: add map theme override to decouple map light/dark from system theme

### DIFF
--- a/app/src/main/java/xyz/malkki/neostumbler/constants/PreferenceKeys.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/constants/PreferenceKeys.kt
@@ -28,5 +28,8 @@ object PreferenceKeys {
     // UI
     const val DYNAMIC_COLOR_THEME = "dynamic_color_theme"
 
+    // Map theme
+    const val MAP_THEME_OVERRIDE = "map_theme_override"
+
     const val GEOCODER_TYPE = "geocoder_type"
 }

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/composables/map/MapSettings.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/composables/map/MapSettings.kt
@@ -42,16 +42,22 @@ import xyz.malkki.neostumbler.data.settings.setEnum
 import xyz.malkki.neostumbler.ui.composables.settings.SettingsToggle
 import xyz.malkki.neostumbler.ui.composables.settings.UrlField
 import xyz.malkki.neostumbler.ui.composables.shared.Dialog
+import xyz.malkki.neostumbler.ui.map.MapThemeOverride
 import xyz.malkki.neostumbler.ui.map.MapTileSource
 
-private typealias TileSourceAndStyleUrl = Pair<MapTileSource, String>
+private data class MapDialogSettings(
+    val tileSource: MapTileSource,
+    val styleUrl: String,
+    val themeOverride: MapThemeOverride,
+)
 
-private fun Settings.selectedMapTileSourceAndStyleUrl(): Flow<TileSourceAndStyleUrl> =
+private fun Settings.mapDialogSettings(): Flow<MapDialogSettings> =
     getSnapshotFlow().map { prefs ->
         val tileSource = prefs.getEnum(PreferenceKeys.MAP_TILE_SOURCE) ?: MapTileSource.DEFAULT
         val styleUrl = prefs.getString(PreferenceKeys.MAP_TILE_SOURCE_CUSTOM_URL) ?: ""
+        val themeOverride = prefs.getEnum(PreferenceKeys.MAP_THEME_OVERRIDE) ?: MapThemeOverride.SYSTEM
 
-        tileSource to styleUrl
+        MapDialogSettings(tileSource, styleUrl, themeOverride)
     }
 
 @Composable
@@ -60,35 +66,39 @@ fun MapSettingsButton(modifier: Modifier, settings: Settings = koinInject()) {
 
     var dialogOpen by rememberSaveable { mutableStateOf(false) }
 
-    val selectedMapTileSourceAndStyleUrl by
-        settings.selectedMapTileSourceAndStyleUrl().collectAsStateWithLifecycle(initialValue = null)
+    val currentDialogSettings by
+        settings.mapDialogSettings().collectAsStateWithLifecycle(initialValue = null)
 
     if (dialogOpen) {
-        val selectedMapTileSource = selectedMapTileSourceAndStyleUrl?.first
-        val styleUrl = selectedMapTileSourceAndStyleUrl?.second
+        val dialogSettings = currentDialogSettings
 
-        MapSettingsDialog(
-            currentSettings = selectedMapTileSource!! to styleUrl!!,
-            onCloseDialog = { newSettings ->
-                if (newSettings != null) {
-                    coroutineScope.launch {
-                        settings.edit {
-                            setEnum(PreferenceKeys.MAP_TILE_SOURCE, newSettings.first)
-
-                            setString(PreferenceKeys.MAP_TILE_SOURCE_CUSTOM_URL, newSettings.second)
+        if (dialogSettings != null) {
+            MapSettingsDialog(
+                currentSettings = dialogSettings,
+                onCloseDialog = { newSettings ->
+                    if (newSettings != null) {
+                        coroutineScope.launch {
+                            settings.edit {
+                                setEnum(PreferenceKeys.MAP_TILE_SOURCE, newSettings.tileSource)
+                                setString(
+                                    PreferenceKeys.MAP_TILE_SOURCE_CUSTOM_URL,
+                                    newSettings.styleUrl,
+                                )
+                                setEnum(PreferenceKeys.MAP_THEME_OVERRIDE, newSettings.themeOverride)
+                            }
                         }
                     }
-                }
 
-                dialogOpen = false
-            },
-        )
+                    dialogOpen = false
+                },
+            )
+        }
     }
 
     FilledTonalIconButton(
         modifier = modifier,
         onClick = { dialogOpen = true },
-        enabled = selectedMapTileSourceAndStyleUrl != null,
+        enabled = currentDialogSettings != null,
         colors = IconButtonDefaults.filledTonalIconButtonColors(),
     ) {
         Icon(
@@ -101,15 +111,26 @@ fun MapSettingsButton(modifier: Modifier, settings: Settings = koinInject()) {
 
 @Composable
 private fun MapSettingsDialog(
-    currentSettings: TileSourceAndStyleUrl,
-    onCloseDialog: (TileSourceAndStyleUrl?) -> Unit,
+    currentSettings: MapDialogSettings,
+    onCloseDialog: (MapDialogSettings?) -> Unit,
 ) {
-    val selectedTileSource = rememberSaveable { mutableStateOf(currentSettings.first) }
-    val selectedStyleUrl = rememberSaveable { mutableStateOf<String?>(currentSettings.second) }
+    val selectedTileSource = rememberSaveable { mutableStateOf(currentSettings.tileSource) }
+    val selectedStyleUrl = rememberSaveable { mutableStateOf<String?>(currentSettings.styleUrl) }
+    val selectedThemeOverride = rememberSaveable { mutableStateOf(currentSettings.themeOverride) }
+
+    val hasDarkVariant = selectedTileSource.value.sourceUrlDark != null
 
     Dialog(
         title = stringResource(id = R.string.map_tile_source),
-        onDismissRequest = { onCloseDialog(selectedTileSource.value to selectedStyleUrl.value!!) },
+        onDismissRequest = {
+            onCloseDialog(
+                MapDialogSettings(
+                    tileSource = selectedTileSource.value,
+                    styleUrl = selectedStyleUrl.value!!,
+                    themeOverride = selectedThemeOverride.value,
+                )
+            )
+        },
     ) {
         Column {
             Column(
@@ -157,6 +178,61 @@ private fun MapSettingsDialog(
                     label = stringResource(R.string.map_tile_source_custom_style_url),
                     state = selectedStyleUrl,
                 )
+            }
+
+            if (hasDarkVariant) {
+                HorizontalDivider()
+
+                Text(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    text = stringResource(R.string.map_theme_override_title),
+                    style = MaterialTheme.typography.titleSmall,
+                )
+
+                Column(
+                    modifier = Modifier.selectableGroup().padding(bottom = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    MapThemeOverride.entries.forEach { override ->
+                        Row(
+                            Modifier.fillMaxWidth()
+                                .wrapContentHeight()
+                                .defaultMinSize(minHeight = 36.dp)
+                                .selectable(
+                                    selected = override == selectedThemeOverride.value,
+                                    onClick = { selectedThemeOverride.value = override },
+                                    role = Role.RadioButton,
+                                )
+                                .padding(horizontal = 16.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                modifier =
+                                    Modifier.align(Alignment.CenterVertically).padding(top = 4.dp),
+                                selected = override == selectedThemeOverride.value,
+                                onClick = null,
+                            )
+
+                            Text(
+                                modifier =
+                                    Modifier.align(Alignment.CenterVertically)
+                                        .padding(start = 16.dp),
+                                text =
+                                    stringResource(
+                                        when (override) {
+                                            MapThemeOverride.SYSTEM ->
+                                                R.string.map_theme_override_system
+                                            MapThemeOverride.LIGHT ->
+                                                R.string.map_theme_override_light
+                                            MapThemeOverride.DARK ->
+                                                R.string.map_theme_override_dark
+                                        }
+                                    ),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
             }
 
             HorizontalDivider()

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/composables/shared/ComposableMap.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/composables/shared/ComposableMap.kt
@@ -46,6 +46,7 @@ import xyz.malkki.neostumbler.data.settings.getEnumFlow
 import xyz.malkki.neostumbler.data.settings.getStringFlow
 import xyz.malkki.neostumbler.network.HttpCallFactoryProvider
 import xyz.malkki.neostumbler.ui.map.LifecycleAwareMapView
+import xyz.malkki.neostumbler.ui.map.MapThemeOverride
 import xyz.malkki.neostumbler.ui.map.MapTileSource
 
 @Composable
@@ -85,10 +86,22 @@ fun ComposableMap(
             .getStringFlow(PreferenceKeys.MAP_TILE_SOURCE_CUSTOM_URL, "")
             .collectAsStateWithLifecycle(initialValue = "")
 
+    val mapThemeOverride by
+        settings
+            .getEnumFlow(PreferenceKeys.MAP_THEME_OVERRIDE, MapThemeOverride.SYSTEM)
+            .collectAsStateWithLifecycle(initialValue = MapThemeOverride.SYSTEM)
+
+    val useDarkTheme =
+        when (mapThemeOverride) {
+            MapThemeOverride.LIGHT -> false
+            MapThemeOverride.DARK -> true
+            MapThemeOverride.SYSTEM -> isSystemInDarkTheme()
+        }
+
     val mapTileSourceUrl =
         if (mapTileSource == MapTileSource.CUSTOM) {
             customMapStyleUrl
-        } else if (isSystemInDarkTheme() && mapTileSource.sourceUrlDark != null) {
+        } else if (useDarkTheme && mapTileSource.sourceUrlDark != null) {
             mapTileSource.sourceUrlDark!!
         } else {
             mapTileSource.sourceUrl!!

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/map/MapThemeOverride.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/map/MapThemeOverride.kt
@@ -1,0 +1,13 @@
+package xyz.malkki.neostumbler.ui.map
+
+/** User-configurable override for map tile theme (light/dark/system). */
+enum class MapThemeOverride {
+    /** Follow the device system theme (default). */
+    SYSTEM,
+
+    /** Always use the light map style. */
+    LIGHT,
+
+    /** Always use the dark map style when available, otherwise fall back to the light style. */
+    DARK,
+}

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/screens/MapScreen.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/screens/MapScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlin.math.abs
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.location.LocationComponentActivationOptions
@@ -52,10 +53,14 @@ import xyz.malkki.neostumbler.R
 import xyz.malkki.neostumbler.domain.asDomainLatLng
 import xyz.malkki.neostumbler.domain.asMapLibreLatLng
 import xyz.malkki.neostumbler.extensions.checkMissingPermissions
+import xyz.malkki.neostumbler.constants.PreferenceKeys
+import xyz.malkki.neostumbler.data.settings.Settings
+import xyz.malkki.neostumbler.data.settings.getEnumFlow
 import xyz.malkki.neostumbler.ui.composables.map.MapSettingsButton
 import xyz.malkki.neostumbler.ui.composables.shared.ComposableMap
 import xyz.malkki.neostumbler.ui.composables.shared.KeepScreenOn
 import xyz.malkki.neostumbler.ui.composables.shared.PermissionsDialog
+import xyz.malkki.neostumbler.ui.map.MapThemeOverride
 import xyz.malkki.neostumbler.ui.viewmodel.MapViewModel
 import xyz.malkki.neostumbler.utils.maplibre.FlowLocationEngine
 import xyz.malkki.neostumbler.utils.maplibre.needsRecreation
@@ -84,7 +89,10 @@ private const val HEATMAP_LAYER_ID = "neostumbler-heat-map"
 // FIXME: try to break this into smaller pieces and then remove these suppressions
 @Suppress("LongMethod")
 @Composable
-fun MapScreen(mapViewModel: MapViewModel = koinViewModel<MapViewModel>()) {
+fun MapScreen(
+    mapViewModel: MapViewModel = koinViewModel<MapViewModel>(),
+    settings: Settings = koinInject(),
+) {
     val context = LocalContext.current
 
     val coroutineScope = rememberCoroutineScope()
@@ -98,7 +106,17 @@ fun MapScreen(mapViewModel: MapViewModel = koinViewModel<MapViewModel>()) {
     val coverageTileJsonLayerIds by
         mapViewModel.coverageTileJsonLayerIds.collectAsStateWithLifecycle()
 
-    val darkMode = isSystemInDarkTheme()
+    val mapThemeOverride by
+        settings
+            .getEnumFlow(PreferenceKeys.MAP_THEME_OVERRIDE, MapThemeOverride.SYSTEM)
+            .collectAsStateWithLifecycle(initialValue = MapThemeOverride.SYSTEM)
+
+    val darkMode =
+        when (mapThemeOverride) {
+            MapThemeOverride.LIGHT -> false
+            MapThemeOverride.DARK -> true
+            MapThemeOverride.SYSTEM -> isSystemInDarkTheme()
+        }
 
     var geoJsonSource by remember { mutableStateOf(GeoJsonSource(HEATMAP_SOURCE_ID)) }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,10 @@
     <string name="map_tile_source_custom_title">Custom</string>
     <string name="map_tile_source_custom_style_url">Custom map style URL</string>
     <string name="map_show_coverage_layer">Show coverage layer</string>
+    <string name="map_theme_override_title">Map theme</string>
+    <string name="map_theme_override_system">Follow system theme</string>
+    <string name="map_theme_override_light">Always light</string>
+    <string name="map_theme_override_dark">Always dark</string>
     <string name="show_my_location">Show my location</string>
     <string name="permission_rationale_fine_location">
         Creating reports with useful location data needs permission for accurate location


### PR DESCRIPTION
## Summary

- Adds a `MAP_THEME_OVERRIDE` preference with three options: **Follow system theme** (default), **Always light**, and **Always dark**
- The setting is surfaced as a radio group inside the map tile source dialog, visible whenever the selected tile source has a dark variant (OpenFreeMap, VersaTiles)
- Both the tile URL selection (`ComposableMap`) and the visual overlay colors for the coverage layer and heatmap (`MapScreen`) respect the override
- When **Custom** tile source is selected the theme control is hidden (no dark variant)
- Default is `SYSTEM`, so existing behavior is completely unchanged for current users

## Why this matters

Fixes #1095. Users who prefer a light map while the device is in dark mode (or vice versa) have no way to override the system-coupled selection today. The maintainer acknowledged the gap and noted they would consider making it configurable ("I'll think about making this configurable").

## Testing

- Set tile source to OpenFreeMap or VersaTiles; open map settings dialog and confirm a "Map theme" radio group appears with three options
- Select **Always light** — map loads the light style regardless of device dark mode
- Select **Always dark** — map loads the dark style regardless of device light mode
- Select **Follow system theme** — existing system-coupled behavior is restored
- Switch to OpenStreetMap or Custom — the "Map theme" radio group is hidden
- Coverage layer color (orange vs. gold) and heatmap gradient respond to the override, not just tile URL
- Preference survives app restart and tab switching

Fixes #1095
