### PR TITLE
Fix inverted Wi-Fi/cell tower scan interval calculation

### DIFF
--- a/app/feature/active-scan/service/src/main/kotlin/xyz/malkki/neostumbler/activescan/ScanDataCollector.kt
+++ b/app/feature/active-scan/service/src/main/kotlin/xyz/malkki/neostumbler/activescan/ScanDataCollector.kt
@@ -47,7 +47,7 @@ internal class ScanDataCollector(
                             scanThrottled = !scanSettings.ignoreWifiScanThrottling,
                             scanInterval =
                                 speedFlow.map { speed ->
-                                    (speed / scanSettings.wifiScanDistance).seconds
+                                    (scanSettings.wifiScanDistance / speed).seconds
                                 },
                         )
                     } else {
@@ -88,7 +88,7 @@ internal class ScanDataCollector(
                         cellSource.getCellInfoFlow(
                             interval =
                                 speedFlow.map { speed ->
-                                    (speed / scanSettings.cellScanDistance).seconds
+                                    (scanSettings.cellScanDistance / speed).seconds
                                 }
                         )
                     } else {


### PR DESCRIPTION
The Wi-Fi and cell tower scan frequency settings are configured as a distance ("scan every X meters", where a smaller value means scanning more often). ScanDataCollector converts that distance into the time interval between scans based on the current speed, and that interval is used as the delay between consecutive scans.

The conversion was inverted: it computed `speed / scanDistance` instead of `scanDistance / speed`. The time needed to travel a distance is distance / speed, so the previous formula produced a value in units of 1/seconds that was then misinterpreted as a duration.

Because of this inversion, a smaller configured scan distance produced a larger interval. An emitter type configured to be scanned more often (smaller distance) was therefore scanned less often, and vice versa.