### PR TITLE
Show PSC in LTE report details

### DIFF
--- a/app/src/main/java/xyz/malkki/neostumbler/ui/composables/reports/details/ReportDetails.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/composables/reports/details/ReportDetails.kt
@@ -289,6 +289,13 @@ private fun ReportCellsList(cellTowers: List<ReportEmitter<CellTower, String>>) 
                         )
                     }
 
+                    cellTower.emitter.primaryScramblingCode?.let { psc ->
+                        Text(
+                            text = stringResource(R.string.psc, psc),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+
                     Text(
                         text =
                             stringResource(R.string.radio_type, cellTower.emitter.radioType.name),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="mcc">MCC: %s</string>
     <string name="mnc">MNC: %s</string>
     <string name="lac">LAC: %s</string>
+    <string name="psc">PSC: %s</string>
     <string name="radio_type">Type: %s</string>
     <string name="beacon_type">Beacon type: %s</string>
     <string name="beacon_id">ID%1$d: %2$s</string>


### PR DESCRIPTION
## Summary

- Show the primary scrambling code in report cell details when it is available.
- Add a default translatable PSC label alongside the existing MCC, MNC, and LAC labels.

Fixes #1213 

## Validation

- `./gradlew :app:ktfmtCheck :app:compileFdroidDefaultDebugKotlin --console=plain`
- `./gradlew unitTest --console=plain`
